### PR TITLE
Fix the sort order to avid duplicates in the future

### DIFF
--- a/_data/interest.yml
+++ b/_data/interest.yml
@@ -14,10 +14,10 @@ webconcepts:
     - pointer: /series/1/RFC/specs/117/7464
     - pointer: /series/1/RFC/specs/126/7523
     - pointer: /series/1/RFC/specs/128/7540
+    - pointer: /series/1/RFC/specs/139/7644
     - pointer: /series/1/RFC/specs/147/7807
     - pointer: /series/1/RFC/specs/169/8246
     - pointer: /series/1/RFC/specs/173/8288
-    - pointer: /series/1/RFC/specs/139/7644
 
   W3C:
     - pointer: /series/0/TR/specs/27/preload


### PR DESCRIPTION
Sorting eases manual inspection and helps avoid duplicates.